### PR TITLE
Fixing the new style to not have new icon overlapped sometimes

### DIFF
--- a/webroot/update-instructions/style.css
+++ b/webroot/update-instructions/style.css
@@ -48,19 +48,14 @@ pre {
 
 /* NEW entries */
 .new {
-    background: #EEFEEE url('images/new.gif') no-repeat 3px 3px;
-    text-indent: 42px;
+    background-color: #EEFEEE;
     padding: 5px;
     border: 1px solid #AABBAA;
 }
 
-.new li,
-.new div,
-.new pre {
-    /* Sub-sections of new thingy, take out indentions */
-    text-indent: 0px;
+.new::before {
+    content: url(images/new.gif);
 }
-
 
 /*  BUTTONS  */
 


### PR DESCRIPTION
For some reason `text-indent` just wasn't doing it on some of the "new" entries.  Using `::before` instead seems to do the trick.